### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/.changes/unreleased/NOTES-20240229-094602.yaml
+++ b/.changes/unreleased/NOTES-20240229-094602.yaml
@@ -1,7 +1,0 @@
-kind: NOTES
-body: 'all: This Go module has been updated to Go 1.21 per the [Go support policy](https://go.dev/doc/devel/release#policy).
-  It is recommended to review the [Go 1.21 release notes](https://go.dev/doc/go1.21) before upgrading. Any consumers 
-  building on earlier Go versions may experience errors'
-time: 2024-02-29T09:46:02.098099Z
-custom:
-  Issue: "45"

--- a/.changes/unreleased/NOTES-20240906-163615.yaml
+++ b/.changes/unreleased/NOTES-20240906-163615.yaml
@@ -1,0 +1,7 @@
+kind: NOTES
+body: 'all: This Go module has been updated to Go 1.22 per the [Go support policy](https://go.dev/doc/devel/release#policy).
+  It is recommended to review the [Go 1.22 release notes](https://go.dev/doc/go1.22)
+  before upgrading. Any consumers building on earlier Go versions may experience errors.'
+time: 2024-09-06T16:36:15.626814-04:00
+custom:
+  Issue: "73"

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.22', '1.21' ]
+        go-version: [ '1.23', '1.22' ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - forcetypeassert
     - gofmt
     - gosimple
+    - govet
     - ineffassign
     - makezero
     - misspell
@@ -22,4 +23,3 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Go module is typically kept up to date with the latest `terraform-plugin-fr
 
 This Go module follows `terraform-plugin-framework` Go compatibility.
 
-Currently that means Go **1.21** must be used when developing and testing code.
+Currently that means Go **1.22** must be used when developing and testing code.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/hashicorp/terraform-plugin-framework-jsontypes
 
-go 1.21
+go 1.22.0
 
-toolchain go1.21.3
+toolchain go1.22.7
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.21
+go 1.22.7
 
 require github.com/hashicorp/copywrite v0.19.0
 


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the minimum Go module to 1.22.0 to allow for all patch versions in 1.22. Toolchain is using the latest 1.22.7

### Note

This PR removes a changelog that hasn't been released about 1.21, since we haven't released it in a while 😄 