### PR TITLE
[Chore] Upgrade Go version to 1.24

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.23', '1.22' ]
+        go-version: [ '1.25', '1.24' ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,13 @@
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - gofmt
     - gosimple
@@ -19,7 +19,7 @@ linters:
     - paralleltest
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
+    - usetesting

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Go module is typically kept up to date with the latest `terraform-plugin-fr
 
 This Go module follows `terraform-plugin-framework` Go compatibility.
 
-Currently that means Go **1.22** must be used when developing and testing code.
+Currently that means Go **1.24** must be used when developing and testing code.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/terraform-plugin-framework-jsontypes
 
-go 1.22.0
-
-toolchain go1.22.7
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/jsontypes/exact_type_test.go
+++ b/jsontypes/exact_type_test.go
@@ -39,7 +39,7 @@ func TestExactTypeValueFromTerraform(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/jsontypes/exact_value_test.go
+++ b/jsontypes/exact_value_test.go
@@ -62,7 +62,7 @@ func TestExactValidateAttribute(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -125,7 +125,7 @@ func TestExactValidateParameter(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -210,7 +210,7 @@ func TestExactUnmarshal(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/jsontypes/normalized_type_test.go
+++ b/jsontypes/normalized_type_test.go
@@ -39,7 +39,7 @@ func TestNormalizedTypeValueFromTerraform(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/jsontypes/normalized_value_test.go
+++ b/jsontypes/normalized_value_test.go
@@ -145,7 +145,7 @@ func TestNormalizedStringSemanticEquals(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -208,7 +208,7 @@ func TestNormalizedValidateAttribute(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -271,7 +271,7 @@ func TestNormalizedValidateParameter(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -356,7 +356,7 @@ func TestNormalizedUnmarshal(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.22.7
+go 1.24.0
 
 require github.com/hashicorp/copywrite v0.21.0
 


### PR DESCRIPTION
#!/usr/bin/env bash
set -e

repo_dir="/Users/sgoods/Hashicorp/terraform-provider-" # Path to utility provider directory repos
pr_branch="SBGoods/update-go-version" # Name of git branch to be created for PR
pr_body_file_path="/Users/sgoods/Documents/go-update-pr-body.md" # Path to file with PR body content
targ_go_ver="1.24" # Go version to upgrade to (Format: major.minor)
prev_go_ver="1.23" # Current go version; used in sed to update readme (Format: major.minor)

utility_providers=("archive" "cloudinit" "dns" "external" "http" "local" "null" "random" "time" "tls")
for provider in ${utility_providers[@]}
do
    cd $repo_dir$provider
    echo Switched directory to $PWD
    # Checkout and update main branch
    git checkout main
    git pull

    # Verify that the working tree is clean
    if [ -z "$(git status --porcelain)" ]; then
        echo Working tree is clean, continuing
    else
        echo ERROR: Working tree is not clean, exiting...
        exit 1 # terminate and indicate error
    fi

    # Get current go version from go.mod
    # NOTE: The parsing with the cut command here is pretty brittle as in makes the assumption
    # that the go major version is 1 character long and minor version is 2 characters long.
    curr_go_ver=$(go mod edit -print | grep -E 'go [0-9]+\.[0-9]+\.[0-9]+' | cut -c 4-7)

    # Skip update if go version in up-to-date
    if test $targ_go_ver = $curr_go_ver
    then
        echo $provider repo already has updated go.mod version, skipping.
        continue
    fi

    echo $curr_go_ver

    # Create and checkout branch for update
    git checkout -b $pr_branch

    # Update go.mod Go version
    go get go@$targ_go_ver
    go mod tidy
    # Go to the tools module and update go.mod Go version
    cd tools/
    go get go@$targ_go_ver
    go mod tidy
    # Update readme comment to correct version
    cd ..
    sed -E -i '' "s#\[Go\].* \($prev_go_ver)#[Go](https://go.dev/doc/install) ($targ_go_ver)#" README.md
    # Commit changes, push, and open PR
    git add .
    git commit -m "update Go version to $targ_go_ver"
    git push --set-upstream origin $pr_branch
    gh repo set-default hashicorp/terraform-provider-$provider
    gh pr create --title "[Chore] Upgrade Go version to $targ_go_ver" -F $pr_body_file_path
    # Get PR number of open PR
    pr_num=$(gh pr view $pr_branch --json number --jq '.number')
    # Enable squash auto-merge on PR and delete branch once merged
    gh pr merge $pr_num --auto -d -s

    # Add changelog entry and push to PR (Not required for utility providers if no release is planned ref: https://github.com/hashicorp/terraform-provider-dns/pull/587#pullrequestreview-3294718188)
    #
    # changie new -i=false -k="NOTES" -b="This Go module has been updated to Go $targ_go_ver per the [Go support policy](https://golang.org/doc/devel/release.html#policy). Any consumers building on earlier Go versions may experience errors." -m="Issue=$pr_num"
    # git add .
    # git commit -m "add changelog entry"
    # git push
done
