### PR TITLE
[Chore] Upgrade Go version to 1.24

### DIFF
--- a/.changes/unreleased/NOTES-20250317-095651.yaml
+++ b/.changes/unreleased/NOTES-20250317-095651.yaml
@@ -1,7 +1,0 @@
-kind: NOTES
-body: 'all: This Go module has been updated to Go 1.23 per the [Go support policy](https://go.dev/doc/devel/release#policy).
-  It is recommended to review the [Go 1.23 release notes](https://go.dev/doc/go1.23)
-  before upgrading. Any consumers building on earlier Go versions may experience errors.'
-time: 2025-03-17T09:56:51.459706-04:00
-custom:
-    Issue: "105"

--- a/.changes/unreleased/NOTES-20251007-174639.yaml
+++ b/.changes/unreleased/NOTES-20251007-174639.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: This Go module has been updated to Go 1.24 per the [Go support policy](https://golang.org/doc/devel/release.html#policy). Any consumers building on earlier Go versions may experience errors.
+time: 2025-10-07T17:46:39.448016-04:00
+custom:
+    Issue: "129"

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.24', '1.23' ]
+        go-version: [ '1.25', '1.24' ]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Go module is typically kept up to date with the latest `terraform-plugin-fr
 
 This Go module follows `terraform-plugin-framework` Go compatibility.
 
-Currently that means Go **1.23** must be used when developing and testing code.
+Currently that means Go **1.24** must be used when developing and testing code.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/terraform-plugin-framework-jsontypes
 
-go 1.23.0
-
-toolchain go1.23.7
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,8 +2,6 @@ module tools
 
 go 1.24.0
 
-toolchain go1.24.2
-
 require github.com/hashicorp/copywrite v0.22.0
 
 require (

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,8 @@
 module tools
 
-go 1.23.7
+go 1.24.0
+
+toolchain go1.24.2
 
 require github.com/hashicorp/copywrite v0.22.0
 


### PR DESCRIPTION
## Description

Updates `go.mod` and `tools/go.mod` to next Go version.

Note: auto-merge has been turned on for this repo.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
N/A
