### PR TITLE
[Chore] Upgrade Go version to 1.25

### DIFF
--- a/.changes/unreleased/NOTES-20260313-101521.yaml
+++ b/.changes/unreleased/NOTES-20260313-101521.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: This Go module has been updated to Go 1.25 per the [Go support policy](https://golang.org/doc/devel/release.html#policy). Any consumers building on earlier Go versions may experience errors.
+time: 2026-03-13T10:15:21.812649-04:00
+custom:
+    Issue: "152"

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.25', '1.24' ]
+        go-version: [ '1.25', '1.26' ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Go module is typically kept up to date with the latest `terraform-plugin-fr
 
 This Go module follows `terraform-plugin-framework` Go compatibility.
 
-Currently that means Go **1.24** must be used when developing and testing code.
+Currently that means Go **1.25** must be used when developing and testing code.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-plugin-framework-jsontypes
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.24.0
+go 1.25.0
 
 require github.com/hashicorp/copywrite v0.25.1
 


### PR DESCRIPTION
## Description

Updates `go.mod` and `tools/go.mod` to next Go version.

Note: auto-merge has been turned on for this repo.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
N/A
